### PR TITLE
:bug: Fix verify-pr action

### DIFF
--- a/cmd/verify-pr/action.yml
+++ b/cmd/verify-pr/action.yml
@@ -10,5 +10,5 @@ runs:
   - name: Set up Go
     uses: actions/setup-go@v3
   - name: Run verify
-    run: go run ${GITHUB_ACTION_PATH}/verify-pr.go
+    run: cd ${GITHUB_ACTION_PATH} && go mod download && go run verify-pr.go
     shell: bash


### PR DESCRIPTION
Currently, the action will fail to run in other project's workflows because of failures to resolve dependencies:

```
Run go run ${GITHUB_ACTION_PATH}/verify-pr.go
Error: ../../_actions/konveyor/release-tools/main/cmd/verify-pr/verify-pr.go:11:2: no required module provides package github.com/google/go-github/v49/github; to add it:
	go get github.com/google/go-github/v49/github
Error: ../../_actions/konveyor/release-tools/main/cmd/verify-pr/verify-pr.go:12:2: no required module provides package github.com/konveyor/release-tools/action; to add it:
	go get github.com/konveyor/release-tools/action
Error: ../../_actions/konveyor/release-tools/main/cmd/verify-pr/verify-pr.go:13:2: no required module provides package github.com/konveyor/release-tools/pr; to add it:
	go get github.com/konveyor/release-tools/pr
Error: Process completed with exit code 1.
```

Moving to the action's directory should resolve this problem.

Signed-off-by: David Zager <david.j.zager@gmail.com>