### PR TITLE
:sparkles: Tell people they are using emoji

### DIFF
--- a/pr/errors.go
+++ b/pr/errors.go
@@ -1,0 +1,49 @@
+package pr
+
+import (
+	"fmt"
+)
+
+var emojiAliasMap = map[string]string{
+	emojiFeature:  PrefixFeature,
+	emojiBugFix:   PrefixBugFix,
+	emojiDocs:     PrefixDocs,
+	emojiInfra:    PrefixInfra,
+	emojiBreaking: PrefixBreaking,
+	emojiNoNote:   PrefixNoNote,
+}
+
+type PRTypeError struct {
+	title string
+}
+
+func (e PRTypeError) Error() string {
+	return fmt.Sprintf(`No matching PR type indicator found in title.
+
+I saw a title of %#q, which doesn't seem to have any of the acceptable prefixes.
+
+You need to have one of these as the prefix of your PR title:
+- Breaking change: (%#q)
+- Non-breaking feature: (%#q)
+- Bug fix: (%#q)
+- Docs: (%#q)
+- Infra/Tests/Other: (%#q)
+- No release note: (%#q)
+
+More details can be found at [konveyor/release-tools/VERSIONING.md](https://github.com/konveyor/release-tools/VERSIONING.md).`,
+		e.title, PrefixBreaking, PrefixFeature, PrefixBugFix, PrefixDocs, PrefixInfra, PrefixNoNote)
+}
+
+type PRTypeUsedEmojiError struct {
+	PRTypeError
+	emojiUsed rune
+}
+
+func (e PRTypeUsedEmojiError) Error() string {
+	alias, _ := emojiAliasMap[string(e.emojiUsed)]
+	return fmt.Sprintf(`Looks like you used an emoji character, %#q instead of it's alias %#q.
+
+Please use the alias %#q instead.
+
+%s`, e.emojiUsed, alias, alias, e.PRTypeError.Error())
+}

--- a/pr/prefix_test.go
+++ b/pr/prefix_test.go
@@ -77,6 +77,15 @@ func TestTypeFromTitle(t *testing.T) {
 			expectedTitle: "Add new feature",
 			expectedError: nil,
 		},
+		{
+			title:         "👻 I should have used the alias",
+			expectedType:  UnknownPR,
+			expectedTitle: "👻 I should have used the alias",
+			expectedError: PRTypeUsedEmojiError{
+				PRTypeError: PRTypeError{title: "👻 I should have used the alias"},
+				emojiUsed: rune('👻'),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When a user provides emoji instead of the emoji alias (ie. 👻 instead of :ghost:), we should let them know because it might not be obvious why the check is failing when looking at the GitHub UI.