### PR TITLE
:ghost: create-release: specify the repo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -132,6 +132,7 @@ jobs:
 
       - uses: ncipollo/release-action@v1
         with:
+          repo: ${{ inputs.repository }}
           tag: ${{ inputs.version }}
           commit: ${{ steps.changelog.outputs.sha }}
           bodyFile: ${{ env.release_doc }}


### PR DESCRIPTION
In order for create-release action to work is to specify the repo since we aren't necessarily running this from the same repo where the release is being created.