### PR TITLE
:sparkles: add workflow to prepare a repository for release

### DIFF
--- a/.github/workflows/prep-release.yaml
+++ b/.github/workflows/prep-release.yaml
@@ -1,0 +1,83 @@
+# This workflow prepares a repository for release, it does following:
+# - updates specified base images used in the Dockerfile to use the right tags
+# - updates specified go dependencies in go.mod file to point to right branches
+# - commits the results back to the originating branch
+name: Prepare repository for release
+on:
+  workflow_call:
+    inputs:
+      branch_ref:
+        description: Ref of the branch that triggers this workflow.
+        type: string
+        required: true
+      images_to_update:
+        description: List of images in the Dockerfile to update formatted as a JSON array string e.g. '["quay.io/konveyor/analyzer-lsp"]'.
+        type: string
+        required: false
+        default: '[]'
+      go_deps_to_update:
+        description: List of go dependencies to update in go.mod file formatterd as a JSON array string e.g. '["github.com/konveyor/analyzer-lsp"]'.
+        type: string
+        required: false
+        default: '[]'
+      dockerfile:
+        description: Relative path to Dockefile.
+        type: string
+        required: false
+        default: ./Dockerfile
+jobs:
+  prep-for-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract version and branch name
+      id: extract-info
+      run: |
+        if [[ "${BRANCH_REF}" =~ ^refs/heads/release-[0-9]+.[0-9]+$ ]]; then
+          BRANCH=$(echo "$BRANCH_REF" | sed "s,refs/heads/,,")
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+        else
+          echo "branch=NOOP" >> $GITHUB_OUTPUT
+        fi 
+      env:
+        BRANCH_REF: ${{ inputs.branch_ref }}
+
+    - name: Checkout repository
+      if: steps.extract-info.outputs.branch != 'NOOP'
+      uses: actions/checkout@v2
+
+    - name: Update tags of base images in Dockerfile
+      if: steps.extract-info.outputs.branch != 'NOOP'
+      run: |
+        for REPLACE_IMAGE in $(echo "$REPLACE_IMAGES" | jq -r '.[]'); do
+          sed -i "s,${REPLACE_IMAGE}.*$,${REPLACE_IMAGE}:${TAG}," ${DOCKERFILE}
+        done
+      env:
+        REPLACE_IMAGES: ${{ inputs.images_to_update }}
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        TAG: ${{ steps.extract-info.outputs.branch }}
+
+    - name: Update dependency versions in go mod file
+      if: steps.extract-info.outputs.branch != 'NOOP'
+      run: |
+        for REPLACE_DEP in $(echo "$REPLACE_DEPS" | jq -r '.[]'); do
+          go get ${REPLACE_DEP}@${BRANCH}
+        done
+        go mod tidy
+      env:
+        REPLACE_DEPS: ${{ inputs.go_deps_to_update }}
+        BRANCH: ${{ steps.extract-info.outputs.branch }}
+
+    - name: Commit and push changes
+      if: steps.extract-info.outputs.branch != 'NOOP'
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@noreply.konveyor.io"
+        git add .
+        git commit -m "prepare for release ${VERSION}"
+        git push
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_USER: ${{ secrets.GH_USER }}
+        VERSION: ${{ steps.extract-info.outputs.branch }}
+        
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,30 @@ Release Tools
 
 This project contains tooling for creating and managing releases for the Konveyor organization.
 
+## Available Workflows
+
+### Prepare repository for release
+
+See [workflow file here](./github/workflows/prep-release.yaml)
+
+This workflow should be called when a new release branch is created. When invoked, it does the following:
+
+- update specified base images in the Dockerfile to use the right release tags
+- update specified golang deps to track the right release branch
+- commits the results back to the originating branch
+
+Before doing the actual changes, it checks if the originating branch matches the pattern `release-X.Y` where X and Y are integers representing major and minor versions for the release.
+
+It accepts following inputs:
+
+* branch\_ref (Required): This is the ref of the branch. Only branches of format `refs/heads/release-X.Y` will enable the workflow to do the actual replacement of tags in Dockerfile. All other branches are ignored. `${{ github.ref }}` in the original repo should be used to get the value for this variable.
+
+* images\_to\_update: This is a list of images in the Dockerfile for which you want to update the tags. It should be a JSON array string e.g. `'["quay.io/konveyor/operator"]'`. Defaults to `'[]'`.
+
+* go_deps\_to\_update: This is a list of go deps in the go.mod file for which you want to update the branches. It should be a JSON array string e.g. `'["github.com/konveyor/analyzer-lsp"]'`. Defaults to `'[]'`.
+
+* dockerfile: This is the relative path to the Dockerfile in the repo. Defaults to `./Dockerfile`.
+
 # Contributing
 
 We welcome contributions to this project! If you're interested in contributing,


### PR DESCRIPTION
Adds a re-usable workflow to
- update tags of base images in Dockerfile of a repo.
- update go deps
- commit changes back to the repo

Usage of this workflow https://github.com/konveyor/analyzer-lsp/pull/263

Example changes made by the workflow https://github.com/pranavgaikwad/windup-rulesets-yaml/commit/a05d30bdfec7e70a01cb11594e6a7426ba6424ca