### PR TITLE
:sparkles: Release creation improvements

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,6 +22,9 @@ on:
         description: 'The token to use when interacting with GitHub'
         required: true
 
+env:
+  GITHUB_TOKEN: ${{ secrets.token }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -60,35 +63,6 @@ jobs:
           path: ${{ inputs.repository }}
           token: ${{ secrets.token }}
 
-      - name: Find previous release
-        working-directory: ./${{ inputs.repository }}
-        run: |
-          set -x
-          CURRENT_XY=${{ steps.check_tag.outputs.xy_version }}
-
-          # When we are dealing with a version that is NOT pre-release,
-          # we should be generating the changelong against the closest NOT pre-release.
-          if [[ "${{ steps.check_tag.outputs.is_prerelease }}" = "true" ]]; then
-            CLOSEST_TAG=$(git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 --first-parent || echo "")
-            CLOSEST_XY=$(echo ${CLOSEST_TAG} | awk -F. '{print substr($1,2)"."$2}')
-          else
-            CLOSEST_TAG=$(git describe --tags --match "v[0-9]*\.[0-9]*\.[0-9]*" --exclude "*-[\!0-9]*" --abbrev=0 --first-parent || echo "")
-            CLOSEST_XY=$(echo ${CLOSEST_TAG} | awk -F. '{print substr($1,2)"."$2}')
-          fi
-
-          # Check to see if the nearest tag is a full release, only if we have
-          # changed the XY. So, if the version we are releasing is v0.4.1 and
-          # the closest tag is v0.4.0 (obviously), then we don't need to
-          # traverse release-0.4 to determine that v0.4.0 is the correct
-          # CLOSEST_TAG.
-          # Don't forget to check that the branch exists first.
-          if git ls-remote --exit-code --heads origin release-${CLOSEST_XY} && [[ "$CURRENT_XY" != "$CLOSEST_XY" && "$CLOSEST_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            CLOSEST_TAG=$(git describe --tags --match "v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 --first-parent "origin/release-${CLOSEST_XY}")
-          fi
-
-          echo "tag=${CLOSEST_TAG}" >> $GITHUB_OUTPUT
-        id: prev_tag
-
       - name: Make changelog
         working-directory: ./${{ inputs.repository }}
         run: |
@@ -101,13 +75,16 @@ jobs:
           SHA=$(git rev-parse HEAD)
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
 
-          PREV_TAG=${{ steps.prev_tag.outputs.tag }}
-          filterfunc() { git log --pretty=format:%s ${PREV_TAG}..HEAD | grep "\s*:$1:" | sed "s/^\s*:$1:\s*/ * /"; }
+          # Always compare to latest published full release for repository
+          PREV_TAG=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ inputs.repository }}/releases/latest | jq -r '.tag_name')
+          filterfunc() { git log --pretty=format:%s ${PREV_TAG}..HEAD | grep "^\s*:$1:" | sed "s/^\s*:$1:\s*/ * /"; }
+          # Handle scenario where no previous tag exists
+          if [ -z "${PREV_TAG}" ]; then
+            filterfunc() { git log --pretty=format:%s | grep "^\s*:$1:" | sed "s/^\s*:$1:\s*/ * /"; }
+          fi
+
           RELEASE_DOC="${PWD}/release.md"
           echo "release_doc=${RELEASE_DOC}" >> $GITHUB_ENV
-
-          echo "Changes since [${PREV_TAG}](https://github.com/${{ inputs.repository }}/releases/${PREV_TAG})" >> ${RELEASE_DOC}
-          echo "" >> ${RELEASE_DOC}
 
           BREAKING_CHANGES="$(filterfunc warning)"
           if [ -n "${BREAKING_CHANGES}" ]; then
@@ -129,6 +106,16 @@ jobs:
             echo "${BUG_FIXES}" >> ${RELEASE_DOC}
             echo "" >> ${RELEASE_DOC}
           fi
+
+          # Add contributors as GitHub would have added them
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ inputs.repository }}/releases/generate-notes \
+            -f tag_name="${{ inputs.version }}" \
+            -f target_commitish="${{ inputs.ref }}" \
+            -f previous_tag_name="${PREV_TAG}" | jq -r '.body' | grep -Pzo '.*Contributors(.*\n)*' >> ${RELEASE_DOC}
 
           # TODO(djzager): More? could make this workflow accept as an argument whether or not
           # to include other types (ie. seedling, docs)


### PR DESCRIPTION
Big improvements to the release creation process.

1. Use the gh api to get the latest release + always compare against the closest published release.
1. Fix a :bug: in the filterfunc that would grab reverts
1. Use gh api to generate release notes so that we can grab the contributors section.

Fixes konveyor/community#57