### PR TITLE
:seedling: Add v0.7.1 and v0.8.0 milestones, update v0.7.0 due date

### DIFF
--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -140,7 +140,7 @@ labels:
 #   - title: the title for the milestone
 #     description: the description
 #     state: open/closed
-#     due: 
+#     due:
 #
 milestones:
   - title: 0.3-beta.2
@@ -186,6 +186,15 @@ milestones:
   - title: v0.7.0
     description: The v0.7.0 release of Konveyor
     state: open
+    due: 2025-05-20
+  - title: v0.7.1
+    description: The v0.7.1 release of Konveyor
+    state: open
+    due: 2025-06-24
+  - title: v0.8.0
+    description: The v0.8.0 release of Konveyor
+    state: open
+    due: 2025-09-16
   - title: Next
     description: Bucket for work we want to accomplish in the next release
     state: open


### PR DESCRIPTION
Add milestones with due dates currently planned:
  - `v0.7.1` on 2025-June-24
  - `v0.8.0` on 2025-September-16

Update due date for `v0.7.0` to 2025-May-20.