### PR TITLE
:seedling: Add support for Test PRs

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -96,6 +96,11 @@ jobs:
             { echo "## :bug: Bug Fixes"; echo "${BUG_FIXES}"; echo ""; } >> "${RELEASE_DOC}"
           fi
 
+          TEST_TUBES="$(filterfunc test_tube)"
+          if [ -n "${TEST_TUBES}" ]; then
+            { echo "## :test_tube: Integration or E2E tests"; echo "${TEST_TUBES}"; echo ""; } >> "${RELEASE_DOC}"
+          fi
+
           NEW_CONTRIB=$(echo "${NOTES}" | sed -n "/Contributors/,\$p")
           if [ -n "${NEW_CONTRIB}" ]; then
             echo "${NEW_CONTRIB}" >> "${RELEASE_DOC}"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,7 +30,7 @@ these guarantees extend to all user accessible API endpoints.
 In order to maintain our guarantees two types of branches will be maintained:
 `main` and `release-X.Y`.
 
-* `main` branch is where all of the development happens. It is not guaranteed 
+* `main` branch is where all of the development happens. It is not guaranteed
   stable and may contain breaking changes.
 * `release-X.Y` where X.Y is the minor version for a release is considered
   stable. These branches will receive backport fixes for critical issues, but no
@@ -67,6 +67,7 @@ a:
 - Patch fix: :bug: (`:bug:`)
 - Docs: :book: (`:book:`)
 - Infra/Tests/Other: :seedling: (`:seedling:`)
+- Integration/E2E tests: :test_tube: (`:test_tube:`)
 - No release note: :ghost: (`:ghost:`)
 
 Since GitHub supports emoji aliases (ie. `:ghost:`), there is no need to include

--- a/cmd/verify-pr/action.yml
+++ b/cmd/verify-pr/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
   - name: Set up Go
-    uses: actions/setup-go@v3
+    uses: actions/setup-go@v5
   - name: Run verify
     run: cd ${GITHUB_ACTION_PATH} && go mod download && go run verify-pr.go
     shell: bash

--- a/pkg/pr/prefix.go
+++ b/pkg/pr/prefix.go
@@ -17,6 +17,7 @@ const (
 	InfraPR    PRType = "infra"
 	BreakingPR PRType = "breaking"
 	NoNotePR   PRType = "nonote"
+	TestPR     PRType = "test"
 
 	// TODO(djzager): Should we allow emoji?
 	PrefixFeature  string = ":sparkles:"
@@ -25,6 +26,7 @@ const (
 	PrefixInfra    string = ":seedling:"
 	PrefixBreaking string = ":warning:"
 	PrefixNoNote   string = ":ghost:"
+	PrefixTestTube string = ":test_tube:"
 
 	emojiFeature  = string('✨')
 	emojiBugFix   = string('🐛')
@@ -32,6 +34,7 @@ const (
 	emojiInfra    = string('🌱')
 	emojiBreaking = string('⚠')
 	emojiNoNote   = string('👻')
+	emojiTestTube = string('🧪')
 )
 
 // Extracted from kubernetes/test-infra/prow/plugins/wip/wip-label.go
@@ -75,16 +78,20 @@ func TypeFromTitle(title string) (PRType, string, error) {
 	case strings.HasPrefix(title, PrefixNoNote):
 		title = strings.TrimPrefix(title, PrefixNoNote)
 		prType = NoNotePR
+	case strings.HasPrefix(title, PrefixTestTube):
+		title = strings.TrimPrefix(title, PrefixTestTube)
+		prType = TestPR
 	default:
 		if strings.HasPrefix(title, emojiFeature) ||
 			strings.HasPrefix(title, emojiBugFix) ||
 			strings.HasPrefix(title, emojiDocs) ||
 			strings.HasPrefix(title, emojiInfra) ||
 			strings.HasPrefix(title, emojiBreaking) ||
-			strings.HasPrefix(title, emojiNoNote) {
+			strings.HasPrefix(title, emojiNoNote) ||
+			strings.HasPrefix(title, emojiTestTube) {
 			return UnknownPR, title, PRTypeUsedEmojiError{
 				PRTypeError: PRTypeError{title: title},
-				emojiUsed: []rune(title)[0],
+				emojiUsed:   []rune(title)[0],
 			}
 		}
 		return UnknownPR, title, PRTypeError{title: title}

--- a/pkg/pr/prefix_test.go
+++ b/pkg/pr/prefix_test.go
@@ -83,8 +83,20 @@ func TestTypeFromTitle(t *testing.T) {
 			expectedTitle: "👻 I should have used the alias",
 			expectedError: PRTypeUsedEmojiError{
 				PRTypeError: PRTypeError{title: "👻 I should have used the alias"},
-				emojiUsed: rune('👻'),
+				emojiUsed:   rune('👻'),
 			},
+		},
+		{
+			title:         "WIP: :test_tube: Integration test",
+			expectedType:  TestPR,
+			expectedTitle: "Integration test",
+			expectedError: nil,
+		},
+		{
+			title:         ":test_tube: Integration test",
+			expectedType:  TestPR,
+			expectedTitle: "Integration test",
+			expectedError: nil,
 		},
 	}
 


### PR DESCRIPTION
Add support for Test PRs using the :test_tube: / `:test_tube:` emoji.  This will better support e2e tests living in the same repository as the application code.  See https://github.com/konveyor/tackle2-ui/pull/2511.

  - PRs with the `:test_tube:` emoji are now considered Test PRs
  - The PR type is now displayed in the changelog as "Integration or E2E tests"
  - Added documentation to VERSIONING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new PR annotation type for Integration/E2E tests, using the :test_tube: emoji.
  * Changelog generation now includes a dedicated section for Integration or E2E test entries.

* **Documentation**
  * Updated documentation to describe the new Integration/E2E test PR annotation.

* **Tests**
  * Added test cases to verify correct handling of the new :test_tube: PR prefix.

* **Chores**
  * Upgraded the Go setup action in the GitHub workflow to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->