### PR TITLE
Adding cherry-pick title

### DIFF
--- a/pkg/pr/prefix.go
+++ b/pkg/pr/prefix.go
@@ -18,15 +18,17 @@ const (
 	BreakingPR PRType = "breaking"
 	NoNotePR   PRType = "nonote"
 	TestPR     PRType = "test"
+	CherryPick PRType = "cherry-pick"
 
 	// TODO(djzager): Should we allow emoji?
-	PrefixFeature  string = ":sparkles:"
-	PrefixBugFix   string = ":bug:"
-	PrefixDocs     string = ":book:"
-	PrefixInfra    string = ":seedling:"
-	PrefixBreaking string = ":warning:"
-	PrefixNoNote   string = ":ghost:"
-	PrefixTestTube string = ":test_tube:"
+	PrefixFeature    string = ":sparkles:"
+	PrefixBugFix     string = ":bug:"
+	PrefixDocs       string = ":book:"
+	PrefixInfra      string = ":seedling:"
+	PrefixBreaking   string = ":warning:"
+	PrefixNoNote     string = ":ghost:"
+	PrefixTestTube   string = ":test_tube:"
+	PrefixCherryPick string = ":cherries:"
 
 	emojiFeature  = string('✨')
 	emojiBugFix   = string('🐛')
@@ -81,6 +83,9 @@ func TypeFromTitle(title string) (PRType, string, error) {
 	case strings.HasPrefix(title, PrefixTestTube):
 		title = strings.TrimPrefix(title, PrefixTestTube)
 		prType = TestPR
+	case strings.HasPrefix(title, PrefixCherryPick):
+		title = strings.TrimPrefix(title, PrefixCherryPick)
+		prType = CherryPick
 	default:
 		if strings.HasPrefix(title, emojiFeature) ||
 			strings.HasPrefix(title, emojiBugFix) ||


### PR DESCRIPTION
Adding ability for cherry-picks to be labeled as such with :cherries:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying cherry-pick pull requests with an emoji prefix (🍒) in titles, enabling better categorization and recognition of cherry-picked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->