### PR TITLE
:seedling: VerifyPR: Disable Go cache to prevent tar warnings

### DIFF
--- a/cmd/verify-pr/action.yml
+++ b/cmd/verify-pr/action.yml
@@ -13,6 +13,8 @@ runs:
   steps:
   - name: Set up Go
     uses: actions/setup-go@v5
+    with:
+      cache: false
   - name: Run verify
     id: verify
     run: cd ${GITHUB_ACTION_PATH} && go mod download && go run verify-pr.go


### PR DESCRIPTION
  ## Summary

  Disables Go module caching in the verify-pr action to eliminate 11,057 tar warnings during cache restoration.

  ## Problem

  `actions/setup-go@v5` enables caching by default, which conflicts with Go toolchain downloads and floods CI logs with "Cannot open: File exists" warnings.

  ## Solution

  Set `cache: false` in the setup-go step. Caching provides no benefit here since the action only runs `go run` once per workflow execution.

  ## Impact

  - Eliminates 11,000+ warning lines from workflow logs
  - No performance impact (cache isn't useful for one-time runs)
  - Cleaner CI output for easier debugging

  Fixes #191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go setup process to disable automatic caching during verification runs, helping ensure more consistent and predictable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->